### PR TITLE
Bump jackson.version from 2.9.8 to 2.12.1 in /RecommenderWeb

### DIFF
--- a/RecommenderWeb/pom.xml
+++ b/RecommenderWeb/pom.xml
@@ -19,7 +19,7 @@
 		<spring.version>5.1.5.RELEASE</spring.version>
 		<spring.data.version>2.1.3.RELEASE</spring.data.version>
 		<hibernate.version>5.4.1.Final</hibernate.version>
-		<jackson.version>2.9.8</jackson.version>
+		<jackson.version>2.12.1</jackson.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Bumps `jackson.version` from 2.9.8 to 2.12.1.

Updates `jackson-core` from 2.9.8 to 2.12.1
- [Release notes](https://github.com/FasterXML/jackson-core/releases)
- [Commits](https://github.com/FasterXML/jackson-core/compare/jackson-core-2.9.8...jackson-core-2.12.1)

Updates `jackson-databind` from 2.9.8 to 2.12.1
- [Release notes](https://github.com/FasterXML/jackson/releases)
- [Commits](https://github.com/FasterXML/jackson/commits)

Updates `jackson-annotations` from 2.9.8 to 2.12.1
- [Release notes](https://github.com/FasterXML/jackson/releases)
- [Commits](https://github.com/FasterXML/jackson/commits)

Signed-off-by: dependabot[bot] <support@github.com>